### PR TITLE
Agregar prueba de ISBN inválido y validación de serializer

### DIFF
--- a/apps/libros/serializers.py
+++ b/apps/libros/serializers.py
@@ -33,3 +33,8 @@ class LibroSerializer(serializers.ModelSerializer):
             'calificacion', 'stock'
         ]
         read_only_fields = ['disponible']
+
+    def validate_isbn(self, value):
+        if len(value) != 13 or not value.isdigit():
+            raise serializers.ValidationError('El ISBN debe tener 13 dígitos numéricos.')
+        return value

--- a/apps/libros/tests.py
+++ b/apps/libros/tests.py
@@ -75,6 +75,21 @@ class LibrosAPITest(APITestCase):
         self.assertEqual(response.status_code, 201)
         self.assertTrue(Libro.objects.filter(titulo="Nuevo Libro").exists())
 
+    def test_crear_libro_isbn_invalido(self):
+        url = reverse('libro-list')
+        data = {
+            "titulo": "Libro ISBN inválido",
+            "autor_id": self.autor.id,
+            "categoria_id": self.categoria.id,
+            "isbn": "1234567890",  # Menos de 13 dígitos
+            "fecha_publicacion": "2020-01-01",
+            "descripcion": "ISBN incorrecto",
+            "stock": 5
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(Libro.objects.filter(titulo="Libro ISBN inválido").exists())
+
     def test_update_libro(self):
         url = reverse('libro-detail', args=[self.libro.id])
         data = {


### PR DESCRIPTION
## Summary
- Agrega validación de longitud del ISBN en el serializer de libros
- Añade prueba que verifica que un libro con ISBN inválido retorna 400 y no se crea

## Testing
- `SECRET_KEY='dummysecret' python manage.py test apps.libros -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68b446082130832dada0f481fbc39ab5