### PR TITLE
Allow returning overdue loans

### DIFF
--- a/apps/prestamos/models.py
+++ b/apps/prestamos/models.py
@@ -47,7 +47,12 @@ class Prestamo(models.Model):
             errors['usuario'] = 'El usuario ya alcanzó el límite de préstamos permitidos.'
         
         # Validar fecha de devolución esperada
-        if self.fecha_devolucion_esperada and self.fecha_devolucion_esperada < timezone.now().date():
+        # Solo se considera inválida si la fecha ya pasó y el préstamo aún no fue devuelto
+        if (
+            self.fecha_devolucion_esperada
+            and self.fecha_devolucion_esperada < timezone.now().date()
+            and self.fecha_devolucion is None
+        ):
             errors['fecha_devolucion_esperada'] = 'La fecha de devolución esperada no puede ser en el pasado.'
         
         if errors:

--- a/apps/prestamos/tests.py
+++ b/apps/prestamos/tests.py
@@ -48,7 +48,19 @@ class PrestamosAPITest(APITestCase):
     def test_devolver_prestamo(self):
         url = reverse('prestamo-devolver', args=[self.prestamo.id])
         response = self.client.post(url)
-        self.assertIn(response.status_code, [200, 302]) 
+        self.assertIn(response.status_code, [200, 302])
+        self.prestamo.refresh_from_db()
+        self.assertIsNotNone(self.prestamo.fecha_devolucion)
+
+    def test_devolver_prestamo_con_fecha_vencida(self):
+        # Simular que la fecha de devolución esperada ya pasó
+        Prestamo.objects.filter(id=self.prestamo.id).update(
+            fecha_devolucion_esperada=date.today() - timedelta(days=1)
+        )
+
+        url = reverse('prestamo-devolver', args=[self.prestamo.id])
+        response = self.client.post(url)
+        self.assertIn(response.status_code, [200, 302])
         self.prestamo.refresh_from_db()
         self.assertIsNotNone(self.prestamo.fecha_devolucion)
 


### PR DESCRIPTION
## Summary
- Permit saving loans whose expected return date is in the past once the book has been returned
- Add regression test ensuring overdue loans can be returned

## Testing
- `python manage.py test apps.prestamos.tests.PrestamosAPITest.test_devolver_prestamo`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b44a7be050832d84e960f660c183ae